### PR TITLE
Add LaTeX CI/CD workflows and example document SSC_D-M001

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,107 @@
+# =============================================================================
+# CI workflow: build PDF on pull-request and on merge to main
+#
+# This workflow calls the reusable latex-build-reusable.yml.
+# Child repos reference ejoliet/sandbox's reusable workflow directly;
+# this file is the "self-hosted" caller for the parent repo.
+#
+# Document name follows the pattern: SSC_D-[C|T|M|D]NNN
+# =============================================================================
+
+name: CI – Build LaTeX PDF
+
+on:
+  pull_request:
+    branches: ["main"]
+    paths:
+      - "docs/SSC_D-*.tex"
+      - ".github/workflows/ci.yml"
+      - ".github/workflows/latex-build-reusable.yml"
+
+  push:
+    branches: ["main"]
+    paths:
+      - "docs/SSC_D-*.tex"
+      - ".github/workflows/ci.yml"
+      - ".github/workflows/latex-build-reusable.yml"
+
+  # Allow manual runs
+  workflow_dispatch:
+    inputs:
+      doc_name:
+        description: "Document name (SSC_D-[C|T|M|D]NNN, without .tex)"
+        required: false
+        default: SSC_D-M001
+
+concurrency:
+  group: ci-latex-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  # ---------------------------------------------------------------------------
+  # Discover all SSC_D-*.tex files and build each one
+  # ---------------------------------------------------------------------------
+  discover:
+    name: Discover LaTeX documents
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.scan.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Scan for SSC_D-*.tex files
+        id: scan
+        shell: bash
+        run: |
+          # If triggered manually with a specific doc, use that only.
+          manual="${{ github.event.inputs.doc_name }}"
+          if [[ -n "$manual" ]]; then
+            docs="[\"${manual}\"]"
+          else
+            # Auto-discover all matching files under docs/
+            mapfile -t files < <(
+              find docs -maxdepth 1 -name 'SSC_D-[CTMD][0-9][0-9][0-9].tex' \
+                | sed 's|docs/||;s|\.tex$||' | sort
+            )
+            if [[ ${#files[@]} -eq 0 ]]; then
+              echo "::error::No SSC_D-*.tex files found in docs/"
+              exit 1
+            fi
+            # Build JSON array
+            docs=$(printf '%s\n' "${files[@]}" | jq -R . | jq -sc .)
+          fi
+          echo "matrix={\"doc_name\":${docs}}" >> "$GITHUB_OUTPUT"
+          echo "Matrix: {\"doc_name\":${docs}}"
+
+  # ---------------------------------------------------------------------------
+  # Build each discovered document via the reusable workflow
+  # ---------------------------------------------------------------------------
+  build:
+    name: Build ${{ matrix.doc_name }}
+    needs: discover
+    strategy:
+      matrix: ${{ fromJson(needs.discover.outputs.matrix) }}
+      fail-fast: false
+    uses: ejoliet/sandbox/.github/workflows/latex-build-reusable.yml@main
+    with:
+      doc_name: ${{ matrix.doc_name }}
+      latex_root: docs
+
+  # ---------------------------------------------------------------------------
+  # Summary job (useful as a single required status check in branch rules)
+  # ---------------------------------------------------------------------------
+  ci-success:
+    name: CI Success
+    runs-on: ubuntu-latest
+    needs: build
+    if: always()
+    steps:
+      - name: Check all builds succeeded
+        shell: bash
+        run: |
+          result="${{ needs.build.result }}"
+          if [[ "$result" != "success" ]]; then
+            echo "::error::One or more LaTeX builds failed (result: $result)"
+            exit 1
+          fi
+          echo "All LaTeX documents compiled successfully."

--- a/.github/workflows/latex-build-reusable.yml
+++ b/.github/workflows/latex-build-reusable.yml
@@ -1,0 +1,115 @@
+# =============================================================================
+# Reusable workflow: compile a LaTeX document to PDF
+#
+# Usage from any repo (caller must reference this file via the parent repo):
+#
+#   jobs:
+#     build-pdf:
+#       uses: ejoliet/sandbox/.github/workflows/latex-build-reusable.yml@main
+#       with:
+#         doc_name: SSC_D-M001          # filename without .tex extension
+#         latex_root: docs              # directory containing the .tex file
+#
+# Inputs
+#   doc_name   – LaTeX filename without extension (e.g. SSC_D-M001).
+#                Pattern: SSC_D-[C|T|M|D]<NNN>
+#   latex_root – subdirectory that contains the .tex file (default: docs)
+#   runs       – number of pdflatex passes (default: 3)
+#
+# Outputs
+#   artifact_name – name of the uploaded artifact (for use by callers)
+# =============================================================================
+
+name: LaTeX Build (Reusable)
+
+on:
+  workflow_call:
+    inputs:
+      doc_name:
+        description: >
+          LaTeX document name without the .tex extension.
+          Pattern: SSC_D-[C|T|M|D]NNN  (e.g. SSC_D-M001)
+        required: true
+        type: string
+
+      latex_root:
+        description: >
+          Directory (relative to repo root) that contains the .tex file.
+        required: false
+        type: string
+        default: docs
+
+      runs:
+        description: Number of pdflatex compilation passes (1–4).
+        required: false
+        type: number
+        default: 3
+
+    outputs:
+      artifact_name:
+        description: Name of the uploaded PDF artifact.
+        value: ${{ jobs.build.outputs.artifact_name }}
+
+jobs:
+  build:
+    name: Compile ${{ inputs.doc_name }}.tex
+    runs-on: ubuntu-latest
+
+    outputs:
+      artifact_name: ${{ steps.meta.outputs.artifact_name }}
+
+    steps:
+      # ------------------------------------------------------------------
+      # 1. Checkout
+      # ------------------------------------------------------------------
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      # ------------------------------------------------------------------
+      # 2. Validate filename against naming convention
+      # ------------------------------------------------------------------
+      - name: Validate document name
+        shell: bash
+        run: |
+          doc="${{ inputs.doc_name }}"
+          if [[ ! "$doc" =~ ^SSC_D-[CTMD][0-9]{3}$ ]]; then
+            echo "::error::doc_name '$doc' does not match SSC_D-[C|T|M|D]NNN pattern."
+            exit 1
+          fi
+          echo "Document name is valid: $doc"
+
+      # ------------------------------------------------------------------
+      # 3. Set artifact metadata
+      # ------------------------------------------------------------------
+      - name: Set artifact metadata
+        id: meta
+        shell: bash
+        run: |
+          artifact="pdf-${{ inputs.doc_name }}-${GITHUB_SHA::8}"
+          echo "artifact_name=${artifact}" >> "$GITHUB_OUTPUT"
+          echo "Artifact name: ${artifact}"
+
+      # ------------------------------------------------------------------
+      # 4. Compile LaTeX → PDF
+      # ------------------------------------------------------------------
+      - name: Compile LaTeX document
+        uses: xu-cheng/latex-action@v3
+        with:
+          root_file: ${{ inputs.doc_name }}.tex
+          working_directory: ${{ inputs.latex_root }}
+          latexmk_use_xelatex: false
+          latexmk_shell_escape: false
+          extra_system_packages: ""
+          args: -pdf -interaction=nonstopmode -halt-on-error
+          # Run multiple passes via latexmk (handles BibTeX / cross-refs)
+
+      # ------------------------------------------------------------------
+      # 5. Upload PDF artifact
+      # ------------------------------------------------------------------
+      - name: Upload PDF artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ steps.meta.outputs.artifact_name }}
+          path: ${{ inputs.latex_root }}/${{ inputs.doc_name }}.pdf
+          if-no-files-found: error
+          retention-days: 30

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,137 @@
+# =============================================================================
+# Release workflow: build PDFs and attach them to a GitHub Release
+#
+# Triggered when a release (or pre-release) is published via the GitHub UI
+# or the gh CLI:
+#   gh release create v1.0.0 --title "Release 1.0.0"
+#
+# All SSC_D-*.tex files are compiled; their PDFs are uploaded as release assets.
+# The release tag is embedded in the PDF filename for traceability.
+#
+# Child repos reference the reusable workflow from this parent repo:
+#   uses: ejoliet/sandbox/.github/workflows/latex-build-reusable.yml@main
+# =============================================================================
+
+name: Release – Publish LaTeX PDFs
+
+on:
+  release:
+    types: [published]
+
+  # Allow manual release builds (e.g. to back-fill assets on an existing release)
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag to attach assets to (e.g. v1.0.0)"
+        required: true
+      doc_name:
+        description: "Specific document to build (blank = all)"
+        required: false
+        default: ""
+
+permissions:
+  contents: write   # needed to upload release assets
+
+jobs:
+  # ---------------------------------------------------------------------------
+  # Discover documents (same logic as CI)
+  # ---------------------------------------------------------------------------
+  discover:
+    name: Discover LaTeX documents
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.scan.outputs.matrix }}
+      release_tag: ${{ steps.tag.outputs.release_tag }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Determine release tag
+        id: tag
+        shell: bash
+        run: |
+          if [[ "${{ github.event_name }}" == "release" ]]; then
+            tag="${{ github.event.release.tag_name }}"
+          else
+            tag="${{ github.event.inputs.tag }}"
+          fi
+          echo "release_tag=${tag}" >> "$GITHUB_OUTPUT"
+          echo "Release tag: ${tag}"
+
+      - name: Scan for SSC_D-*.tex files
+        id: scan
+        shell: bash
+        run: |
+          manual="${{ github.event.inputs.doc_name }}"
+          if [[ -n "$manual" ]]; then
+            docs="[\"${manual}\"]"
+          else
+            mapfile -t files < <(
+              find docs -maxdepth 1 -name 'SSC_D-[CTMD][0-9][0-9][0-9].tex' \
+                | sed 's|docs/||;s|\.tex$||' | sort
+            )
+            if [[ ${#files[@]} -eq 0 ]]; then
+              echo "::error::No SSC_D-*.tex files found in docs/"
+              exit 1
+            fi
+            docs=$(printf '%s\n' "${files[@]}" | jq -R . | jq -sc .)
+          fi
+          echo "matrix={\"doc_name\":${docs}}" >> "$GITHUB_OUTPUT"
+          echo "Matrix: {\"doc_name\":${docs}}"
+
+  # ---------------------------------------------------------------------------
+  # Build each document
+  # ---------------------------------------------------------------------------
+  build:
+    name: Build ${{ matrix.doc_name }}
+    needs: discover
+    strategy:
+      matrix: ${{ fromJson(needs.discover.outputs.matrix) }}
+      fail-fast: false
+    uses: ejoliet/sandbox/.github/workflows/latex-build-reusable.yml@main
+    with:
+      doc_name: ${{ matrix.doc_name }}
+      latex_root: docs
+
+  # ---------------------------------------------------------------------------
+  # Attach compiled PDFs to the GitHub Release
+  # ---------------------------------------------------------------------------
+  publish:
+    name: Attach PDFs to Release
+    runs-on: ubuntu-latest
+    needs: [discover, build]
+    strategy:
+      matrix: ${{ fromJson(needs.discover.outputs.matrix) }}
+      fail-fast: false
+
+    steps:
+      - name: Download PDF artifact
+        uses: actions/download-artifact@v4
+        with:
+          # Artifact name pattern must match what the reusable workflow produces:
+          # pdf-<doc_name>-<short_sha>
+          pattern: "pdf-${{ matrix.doc_name }}-*"
+          merge-multiple: true
+          path: release-assets/
+
+      - name: Rename PDF with release tag
+        id: rename
+        shell: bash
+        run: |
+          tag="${{ needs.discover.outputs.release_tag }}"
+          src="release-assets/${{ matrix.doc_name }}.pdf"
+          dst="release-assets/${{ matrix.doc_name }}_${tag}.pdf"
+          if [[ ! -f "$src" ]]; then
+            echo "::error::Expected PDF not found: $src"
+            ls -la release-assets/ || true
+            exit 1
+          fi
+          mv "$src" "$dst"
+          echo "asset_path=${dst}" >> "$GITHUB_OUTPUT"
+          echo "Renamed to: ${dst}"
+
+      - name: Upload PDF to GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ needs.discover.outputs.release_tag }}
+          files: ${{ steps.rename.outputs.asset_path }}
+          fail_on_unmatched_files: true

--- a/docs/SSC_D-M001.tex
+++ b/docs/SSC_D-M001.tex
@@ -1,0 +1,288 @@
+\documentclass[12pt,a4paper]{article}
+
+% -----------------------------------------------------------------------
+% Packages
+% -----------------------------------------------------------------------
+\usepackage[utf8]{inputenc}
+\usepackage[T1]{fontenc}
+\usepackage{geometry}
+\usepackage{graphicx}
+\usepackage{hyperref}
+\usepackage{booktabs}
+\usepackage{tabularx}
+\usepackage{longtable}
+\usepackage{array}
+\usepackage{enumitem}
+\usepackage{fancyhdr}
+\usepackage{xcolor}
+\usepackage{titlesec}
+\usepackage{datetime2}
+\usepackage{amsmath}
+
+\geometry{margin=2.5cm}
+
+% -----------------------------------------------------------------------
+% Colours & formatting
+% -----------------------------------------------------------------------
+\definecolor{sscblue}{RGB}{0,70,127}
+\definecolor{lightgray}{RGB}{230,230,230}
+
+\titleformat{\section}{\large\bfseries\color{sscblue}}{{\thesection}}{1em}{}[\titlerule]
+\titleformat{\subsection}{\normalsize\bfseries\color{sscblue}}{{\thesubsection}}{1em}{}
+
+% -----------------------------------------------------------------------
+% Header / footer
+% -----------------------------------------------------------------------
+\pagestyle{fancy}
+\fancyhf{}
+\rhead{\small SSC\_D-M001 \textbar{} Rev~1.0}
+\lhead{\small Project Management Plan}
+\rfoot{\small Page \thepage}
+\lfoot{\small \textcopyright{} SSC -- CONFIDENTIAL}
+
+% -----------------------------------------------------------------------
+% Hyperref setup
+% -----------------------------------------------------------------------
+\hypersetup{
+  colorlinks = true,
+  linkcolor  = sscblue,
+  urlcolor   = sscblue,
+  pdftitle   = {SSC\_D-M001 -- Project Management Plan},
+  pdfauthor  = {SSC Team},
+}
+
+% -----------------------------------------------------------------------
+% Document metadata (edit here for each release)
+% -----------------------------------------------------------------------
+\newcommand{\docid}{SSC\_D-M001}
+\newcommand{\doctitle}{Project Management Plan}
+\newcommand{\docrev}{1.0}
+\newcommand{\docdate}{\DTMdate{2026-04-03}}
+\newcommand{\docstatus}{Draft}
+\newcommand{\docauthor}{SSC Team}
+
+% =======================================================================
+\begin{document}
+% =======================================================================
+
+% -----------------------------------------------------------------------
+% Title page
+% -----------------------------------------------------------------------
+\begin{titlepage}
+  \centering
+  \vspace*{2cm}
+
+  {\Huge\bfseries\color{sscblue} \doctitle \par}
+  \vspace{0.5cm}
+  {\large Document ID: \texttt{\docid} \par}
+  \vspace{2cm}
+
+  \begin{tabular}{ll}
+    \textbf{Revision:} & \docrev \\[4pt]
+    \textbf{Date:}     & \docdate \\[4pt]
+    \textbf{Status:}   & \docstatus \\[4pt]
+    \textbf{Author:}   & \docauthor \\
+  \end{tabular}
+
+  \vfill
+  \rule{\linewidth}{0.4pt}\\[4pt]
+  {\small This document is subject to change without notice.\\
+  All rights reserved -- SSC Project.}
+\end{titlepage}
+
+% -----------------------------------------------------------------------
+% Revision history
+% -----------------------------------------------------------------------
+\newpage
+\section*{Document Revision History}
+\begin{tabularx}{\textwidth}{|c|c|X|l|}
+  \hline
+  \rowcolor{lightgray}
+  \textbf{Rev} & \textbf{Date} & \textbf{Description} & \textbf{Author} \\
+  \hline
+  1.0 & 2026-04-03 & Initial release & SSC Team \\
+  \hline
+\end{tabularx}
+
+\newpage
+\tableofcontents
+\newpage
+
+% -----------------------------------------------------------------------
+% 1. Introduction
+% -----------------------------------------------------------------------
+\section{Introduction}
+
+\subsection{Purpose}
+This document defines the Project Management Plan (PMP) for the SSC project.
+It describes the governance structure, planning methodology, risk management
+approach, and quality assurance processes adopted throughout the project
+lifecycle.
+
+\subsection{Scope}
+This plan applies to all activities within the SSC project from initiation
+through to closure. It is applicable to all project team members, stakeholders,
+and subcontractors operating under the SSC programme.
+
+\subsection{Document Naming Convention}
+Documents produced under this project follow the naming convention:
+
+\begin{center}
+  \texttt{SSC\_D-<Category><NNN>}
+\end{center}
+
+\noindent where \texttt{<Category>} is one of:
+
+\begin{description}[labelindent=1cm]
+  \item[\texttt{C}] Configuration \& Interface Control
+  \item[\texttt{T}] Technical Specifications \& Design
+  \item[\texttt{M}] Management \& Planning
+  \item[\texttt{D}] Data, Analysis \& Reports
+\end{description}
+
+\noindent and \texttt{<NNN>} is a zero-padded three-digit sequence number.
+
+\subsection{Applicable Documents}
+\begin{enumerate}
+  \item SSC\_D-T001 -- System Requirements Specification
+  \item SSC\_D-C001 -- Interface Control Document
+  \item SSC\_D-D001 -- Verification \& Validation Report
+\end{enumerate}
+
+% -----------------------------------------------------------------------
+% 2. Project Overview
+% -----------------------------------------------------------------------
+\section{Project Overview}
+
+\subsection{Objectives}
+The primary objectives of the SSC project are:
+\begin{itemize}
+  \item Deliver a fully verified system in accordance with the approved
+        requirements baseline.
+  \item Maintain schedule, cost, and quality within agreed tolerances.
+  \item Ensure traceability from requirements through design to verification.
+\end{itemize}
+
+\subsection{Deliverables}
+Table~\ref{tab:deliverables} lists the key deliverables.
+
+\begin{longtable}{|c|l|l|c|}
+  \hline
+  \rowcolor{lightgray}
+  \textbf{ID} & \textbf{Deliverable} & \textbf{Document} & \textbf{Due} \\
+  \hline
+  \endfirsthead
+  \hline
+  \rowcolor{lightgray}
+  \textbf{ID} & \textbf{Deliverable} & \textbf{Document} & \textbf{Due} \\
+  \hline
+  \endhead
+  D-01 & Project Management Plan   & SSC\_D-M001 & Q1 2026 \\
+  D-02 & System Requirements Spec  & SSC\_D-T001 & Q1 2026 \\
+  D-03 & Preliminary Design Review & SSC\_D-T002 & Q2 2026 \\
+  D-04 & Critical Design Review    & SSC\_D-T003 & Q3 2026 \\
+  D-05 & V\&V Report               & SSC\_D-D001 & Q4 2026 \\
+  \hline
+  \caption{Project Deliverables}
+  \label{tab:deliverables}
+\end{longtable}
+
+% -----------------------------------------------------------------------
+% 3. Organisation & Roles
+% -----------------------------------------------------------------------
+\section{Organisation and Roles}
+
+\subsection{Project Governance}
+The project operates under a standard governance framework consisting of:
+
+\begin{itemize}
+  \item \textbf{Project Board} -- strategic oversight and go/no-go decisions.
+  \item \textbf{Project Manager} -- day-to-day management and reporting.
+  \item \textbf{Technical Lead} -- technical authority and design decisions.
+  \item \textbf{Quality Manager} -- process compliance and audit.
+\end{itemize}
+
+\subsection{Responsibilities Matrix (RACI)}
+\begin{tabularx}{\textwidth}{|X|c|c|c|c|}
+  \hline
+  \rowcolor{lightgray}
+  \textbf{Activity} & \textbf{PM} & \textbf{TL} & \textbf{QM} & \textbf{Board} \\
+  \hline
+  Schedule management   & R & C & I & A \\
+  Technical decisions   & I & R & I & A \\
+  Risk management       & R & C & C & A \\
+  Quality audits        & I & I & R & A \\
+  Budget control        & R & I & I & A \\
+  \hline
+\end{tabularx}
+
+\vspace{6pt}
+\noindent\textit{R = Responsible, A = Accountable, C = Consulted, I = Informed}
+
+% -----------------------------------------------------------------------
+% 4. Risk Management
+% -----------------------------------------------------------------------
+\section{Risk Management}
+
+\subsection{Risk Assessment Process}
+Risks are assessed using a $5 \times 5$ likelihood--impact matrix.
+Risk exposure is calculated as:
+
+\begin{equation}
+  E = L \times I
+\end{equation}
+
+\noindent where $L \in [1,5]$ is the likelihood score and $I \in [1,5]$ is
+the impact score.  Risks with $E \geq 12$ are escalated to the Project Board.
+
+\subsection{Risk Register (excerpt)}
+\begin{tabularx}{\textwidth}{|c|X|c|c|c|X|}
+  \hline
+  \rowcolor{lightgray}
+  \textbf{ID} & \textbf{Risk} & \textbf{L} & \textbf{I} & \textbf{E} & \textbf{Mitigation} \\
+  \hline
+  R-01 & Key personnel unavailability & 3 & 4 & 12 & Cross-train team members \\
+  R-02 & Requirements change late     & 2 & 5 & 10 & Freeze baseline at PDR \\
+  R-03 & CI pipeline failure          & 2 & 3 &  6 & Maintain local build fallback \\
+  \hline
+\end{tabularx}
+
+% -----------------------------------------------------------------------
+% 5. Quality Assurance
+% -----------------------------------------------------------------------
+\section{Quality Assurance}
+
+\subsection{Document Control}
+All project documents are version-controlled in the project repository.
+PDF artefacts are generated automatically via the Continuous Integration
+pipeline described in Section~\ref{sec:ci}.
+
+\subsection{Continuous Integration}\label{sec:ci}
+The project uses GitHub Actions to automate the following tasks:
+
+\begin{itemize}
+  \item Compile all \LaTeX{} sources to PDF on every pull request.
+  \item Publish the compiled PDF as a build artefact for review.
+  \item Attach the signed PDF to GitHub Releases at release time.
+\end{itemize}
+
+% -----------------------------------------------------------------------
+% 6. Glossary
+% -----------------------------------------------------------------------
+\section{Glossary}
+\begin{tabularx}{\textwidth}{|l|X|}
+  \hline
+  \rowcolor{lightgray}
+  \textbf{Term} & \textbf{Definition} \\
+  \hline
+  CI   & Continuous Integration \\
+  PMP  & Project Management Plan \\
+  PDR  & Preliminary Design Review \\
+  CDR  & Critical Design Review \\
+  RACI & Responsible, Accountable, Consulted, Informed \\
+  SSC  & System / Sub-System Controller (project code) \\
+  V\&V & Verification and Validation \\
+  \hline
+\end{tabularx}
+
+\end{document}


### PR DESCRIPTION
- docs/SSC_D-M001.tex: example Project Management Plan in SSC_D-[C|T|M|D]NNN format
- .github/workflows/latex-build-reusable.yml: reusable (workflow_call) workflow
  that accepts doc_name as input; validates naming convention and compiles
  via xu-cheng/latex-action, uploading the PDF as an artifact.
  Child repos inherit this via: uses: ejoliet/sandbox/.github/workflows/latex-build-reusable.yml@main
- .github/workflows/ci.yml: CI workflow triggered on PR and merge to main;
  auto-discovers all SSC_D-*.tex files and calls the reusable workflow for each.
- .github/workflows/release.yml: release workflow triggered on GitHub Release
  published event; builds all docs and attaches tagged PDFs as release assets.

https://claude.ai/code/session_01FVCM8vBUSPMyx46aLxsscw