### PR TITLE
Fix reusable workflow reference: use local path in ci.yml and release.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,7 @@ jobs:
     strategy:
       matrix: ${{ fromJson(needs.discover.outputs.matrix) }}
       fail-fast: false
-    uses: ejoliet/sandbox/.github/workflows/latex-build-reusable.yml@main
+    uses: ./.github/workflows/latex-build-reusable.yml
     with:
       doc_name: ${{ matrix.doc_name }}
       latex_root: docs

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,7 +87,7 @@ jobs:
     strategy:
       matrix: ${{ fromJson(needs.discover.outputs.matrix) }}
       fail-fast: false
-    uses: ejoliet/sandbox/.github/workflows/latex-build-reusable.yml@main
+    uses: ./.github/workflows/latex-build-reusable.yml
     with:
       doc_name: ${{ matrix.doc_name }}
       latex_root: docs

--- a/docs/SSC_D-M001.tex
+++ b/docs/SSC_D-M001.tex
@@ -14,7 +14,7 @@
 \usepackage{array}
 \usepackage{enumitem}
 \usepackage{fancyhdr}
-\usepackage{xcolor}
+\usepackage[table]{xcolor}
 \usepackage{titlesec}
 \usepackage{datetime2}
 \usepackage{amsmath}


### PR DESCRIPTION
## Problem
`ci.yml` and `release.yml` were calling the reusable workflow using the full external path:
```
ejoliet/sandbox/.github/workflows/latex-build-reusable.yml@main
```
This caused GitHub Actions to fail with:
> failed to fetch workflow: workflow was not found

## Fix
Same-repo callers must use the local relative path:
```
./.github/workflows/latex-build-reusable.yml
```
The full `ejoliet/sandbox/...@main` form is only valid for **child/external repos** inheriting this workflow.

## Reference
| Caller | Correct `uses` syntax |
|---|---|
| This repo (`ci.yml`, `release.yml`) | `./.github/workflows/latex-build-reusable.yml` |
| Child repos | `ejoliet/sandbox/.github/workflows/latex-build-reusable.yml@main` |

https://claude.ai/code/session_01FVCM8vBUSPMyx46aLxsscw